### PR TITLE
Update _Main.lua per GetNumGuildMember change

### DIFF
--- a/Common/_Main.lua
+++ b/Common/_Main.lua
@@ -43,7 +43,7 @@ function private.UpdateStatistics()
 
     if IsInGuild() then
         local _
-        People.GuildMembers.Total, _, People.GuildMembers.Online = GetNumGuildMembers()
+        People.GuildMembers.Total, People.GuildMembers.Online = GetNumGuildMembers()
     end
 end
 


### PR DESCRIPTION
There seems to be an undocumented change with GetNumGuildMember (it only returns 2 values now).  Dropped the placeholder value so that total guildies and online guildies lines up again.